### PR TITLE
Fix the issue of missing item or duplicated item when search is used

### DIFF
--- a/src/components/ngx-select-dropdown-component/ngx-select-dropdown.component.html
+++ b/src/components/ngx-select-dropdown-component/ngx-select-dropdown.component.html
@@ -5,7 +5,7 @@
     </button>
     <div class="ngx-dropdown-list-container" *ngIf="toggleDropdown" [style.maxHeight]="config.height">
         <div class="search-container" *ngIf="config.search">
-            <input name="search" [(ngModel)]="searchText" />
+            <input name="search" [(ngModel)]="searchText" autocomplete="off"/>
             <label [ngClass]="{'active': searchText}">
                 <span class="nsdicon-search"></span> {{config.searchPlaceholder}}</label>
         </div>

--- a/src/components/ngx-select-dropdown-component/ngx-select-dropdown.component.ts
+++ b/src/components/ngx-select-dropdown-component/ngx-select-dropdown.component.ts
@@ -274,7 +274,11 @@ export class SelectDropDownComponent implements OnInit, OnChanges, AfterViewInit
    * @param index:  index of the item
    */
   public deselectItem(item: any, index: number) {
-    this.selectedItems.splice(index, 1);
+    this.selectedItems.forEach( (element, i) => {
+      if (item === element) {
+        this.selectedItems.splice(i,1);
+      }
+    });
     if (!this.availableItems.includes(item)) {
       this.availableItems.push(item);
       this.availableItems.sort(this.config.customComparator);
@@ -299,8 +303,13 @@ export class SelectDropDownComponent implements OnInit, OnChanges, AfterViewInit
       this.selectedItems = [];
       this.toggleDropdown = false;
     }
-    this.availableItems.splice(index, 1);
-    this.selectedItems.push(item);
+    this.availableItems.forEach( (element, i) => {
+      if (item === element) {
+        this.selectedItems.push(item);
+        this.availableItems.splice(i,1);
+      }
+    });
+    
     this.selectedItems = [...this.selectedItems];
     this.availableItems = [...this.availableItems];
     this.selectedItems.sort(this.config.customComparator);

--- a/src/components/ngx-select-dropdown-component/ngx-select-dropdown.component.ts
+++ b/src/components/ngx-select-dropdown-component/ngx-select-dropdown.component.ts
@@ -274,7 +274,8 @@ export class SelectDropDownComponent implements OnInit, OnChanges, AfterViewInit
    * @param index:  index of the item
    */
   public deselectItem(item: any, index: number) {
-    this.selectedItems.forEach( (element, i) => {
+
+     this.selectedItems.forEach( (element : any, i : number) => {
       if (item === element) {
         this.selectedItems.splice(i,1);
       }
@@ -303,7 +304,8 @@ export class SelectDropDownComponent implements OnInit, OnChanges, AfterViewInit
       this.selectedItems = [];
       this.toggleDropdown = false;
     }
-    this.availableItems.forEach( (element, i) => {
+
+    this.availableItems.forEach( (element : any, i : number) => {
       if (item === element) {
         this.selectedItems.push(item);
         this.availableItems.splice(i,1);


### PR DESCRIPTION
When searching is used, the index passed into selectItem or deselectItem method is the item index after applying the filter, however, when deleting the item using splice method, the index is based on original option set. So the mismatched index will corrupt the option item collection, and cause the missing item or duplicated item in the dropdown listbox

The fix gets the index based on item, and do not use the index parameter passed into selectItem or deselectItem method.

Please review the fix, and merge it soon if the fix is fine.

Thanks
Jonathan 