### PR TITLE
Update peerdependencies to add support for new angular versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/core": "^4.0.0",
-    "@angular/forms": "^4.0.0"
+    "@angular/common": ">4.0.0",
+    "@angular/core": ">4.0.0",
+    "@angular/forms": ">4.0.0"
   },
   "devDependencies": {
     "node-gyp": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@angular/common": ">4.0.0",
-    "@angular/core": ">4.0.0",
-    "@angular/forms": ">4.0.0"
+    "@angular/common": ">=4.0.0",
+    "@angular/core": ">=4.0.0",
+    "@angular/forms": ">=4.0.0"
   },
   "devDependencies": {
     "node-gyp": "^3.8.0",


### PR DESCRIPTION
Angular is now in version 8, and this module should be compatible with angular 2+, so added this config at peerDependencies to prevent warnings and problems while upgrading angular.