### PR TITLE
Use limitTo=0 to indicate no limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ config = {
         height: 'auto' //height of the list so that if there are more no of items it can show a scroll defaults to auto. With auto height scroll will never appear
         placeholder:'Select' // text to be displayed when no item is selected defaults to Select,
         customComparator: ()=>{} // a custom function using which user wants to sort the items. default is undefined and Array.sort() will be used in that case,
-        limitTo: options.length // a number thats limits the no of options displayed in the UI similar to angular's limitTo pipe
+        limitTo: 0 // number thats limits the no of options displayed in the UI (if zero, options will not be limited)
         moreText: 'more' // text to be displayed whenmore than one items are selected like Option 1 + 5 more
         noResultsFound: 'No results found!' // text to be displayed when no items are found while searching
         searchPlaceholder:'Search' // label thats displayed in search input,

--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -113,7 +113,7 @@
             height: 'auto' //height of the list so that if there are more no of items it can show a scroll defaults to auto. With auto height scroll will never appear
             placeholder:'Select' // text to be displayed when no item is selected defaults to Select,
             customComparator: ()=>{{ '{' }}{{ '}' }} // a custom function using which user wants to sort the items. default is undefined and Array.sort() will be used in that case,
-            limitTo: options.length // a number thats limits the no of options displayed in the UI similar to angular's limitTo pipe
+            limitTo: 0 // number thats limits the no of options displayed in the UI (if zero, options will not be limited)
             moreText: 'more' // text to be displayed whenmore than one items are selected like Option 1 + 5 more
             noResultsFound: 'No results found!' // text to be displayed when no items are found while searching
             searchPlaceholder:'Search' // label thats displayed in search input,

--- a/src/components/ngx-select-dropdown-component/ngx-select-dropdown.component.ts
+++ b/src/components/ngx-select-dropdown-component/ngx-select-dropdown.component.ts
@@ -329,7 +329,6 @@ export class SelectDropDownComponent
       this.availableItems = [
         ...this.options.sort(this.config.customComparator),
       ];
-      this.config.limitTo = this.options.length;
     }
     /* istanbul ignore else */
     if (changes.value) {
@@ -450,7 +449,7 @@ export class SelectDropDownComponent
       search: false,
       placeholder: "Select",
       searchPlaceholder: "Search...",
-      limitTo: this.options.length,
+      limitTo: 0,
       customComparator: undefined,
       noResultsFound: "No results found!",
       moreText: "more",

--- a/src/pipes/limit-to.pipe.spec.ts
+++ b/src/pipes/limit-to.pipe.spec.ts
@@ -113,4 +113,10 @@ describe('ArrayLimitToPipe', () => {
       const pipe = new LimitToPipe();
       expect(pipe.transform('test' as any, 5)).toEqual('test' as any);
    });
+
+   it('should return the full array when 0 limit', () => {
+      const data = JSON.parse(JSON.stringify(testData));
+      const pipe = new LimitToPipe();
+      expect(pipe.transform(data, 0)).toEqual(data);
+   });
 });

--- a/src/pipes/limit-to.pipe.ts
+++ b/src/pipes/limit-to.pipe.ts
@@ -5,7 +5,7 @@ import { Pipe, PipeTransform } from "@angular/core";
 })
 export class LimitToPipe implements PipeTransform {
   public transform(array: any[], itemsCount: number, startIndex: number = 0) {
-    if (!Array.isArray(array)) {
+    if (!Array.isArray(array) || itemsCount === 0) {
       return array;
     }
     return array.slice(startIndex, startIndex + itemsCount);


### PR DESCRIPTION
If options are updated after this component is initialized, any limitTo provided by the user is overwritten by ngOnChanges. Rather than update the limit every time the options are changed, I propose we use the convention limitTo = 0 to indicate no limit.