### PR TITLE
#283, #284 input click close in safari

### DIFF
--- a/projects/ngx-select-dropdown/src/lib/ngx-select-dropdown.component.spec.ts
+++ b/projects/ngx-select-dropdown/src/lib/ngx-select-dropdown.component.spec.ts
@@ -529,7 +529,15 @@ describe("NgxSelectDropdownComponent", () => {
   });
 
   it("Should  blur", () => {
-    component.blur();
+    component.toggleDropdown = true;
+    component.blur(new KeyboardEvent("keydown"));
     expect(component.toggleDropdown).toBeFalsy();
   });
+
+  it("Should  blur not close", () => {
+    component.toggleDropdown = true;
+    component.blur(new MouseEvent('click'));
+    expect(component.toggleDropdown).toBeTruthy();
+  });
+  
 });

--- a/projects/ngx-select-dropdown/src/lib/ngx-select-dropdown.component.ts
+++ b/projects/ngx-select-dropdown/src/lib/ngx-select-dropdown.component.ts
@@ -230,8 +230,12 @@ export class NgxSelectDropdownComponent
   /**
    * Event listener for the blur event to hide the dropdown
    */
-  @HostListener("blur") public blur() {
-    if (!this.insideKeyPress && !this.optionMouseDown) {
+  @HostListener("blur") public blur($event: Event) {
+    if (
+      !this.insideKeyPress &&
+      !this.optionMouseDown &&
+      $event instanceof KeyboardEvent
+    ) {
       this.toggleDropdown = false;
       this.openStateChange();
     }


### PR DESCRIPTION
#### Changes
Fixed the issue of dropdown closing when clicking on the search input in Safari browser.

Fixes #284, #283 

#### Type of change
<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
